### PR TITLE
Update awsroute53.md

### DIFF
--- a/docs/dns/providers/awsroute53.md
+++ b/docs/dns/providers/awsroute53.md
@@ -15,7 +15,7 @@ To use the AWS Route53 DNS API, you need to setup your API key and authenticatio
   - You can either allow all permissions:
     - Allow AmazonRoute53FullAccess for the group.
   - Or restrict permission to the following actions:
-    - route53:ListHostedZones, route53:GetHostedZone, route53:ListResourceRecordSets, route53:ChangeResourceRecordSets, route53:GetChange
+    - route53:ListHostedZones, route53:ListHostedZonesByName, route53:GetHostedZone, route53:ListResourceRecordSets, route53:ChangeResourceRecordSets, route53:GetChange
 
 Here is an example JSON policy:
 
@@ -24,16 +24,49 @@ Here is an example JSON policy:
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "VisualEditor0",
+      "Sid": "AllowListZonesAndGetZone",
       "Effect": "Allow",
       "Action": [
-        "route53:GetChange",
-        "route53:GetHostedZone",
         "route53:ListHostedZones",
-        "route53:ChangeResourceRecordSets",
-        "route53:ListResourceRecordSets"
+        "route53:ListHostedZonesByName",
+        "route53:GetHostedZone"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "AllowListRecordSetsInAllZones",
+      "Effect": "Allow",
+      "Action": "route53:ListResourceRecordSets",
+      "Resource": "arn:aws:route53:::hostedzone/*"
+    },
+    {
+      "Sid": "AllowAcmeTxtChangesOnly",
+      "Effect": "Allow",
+      "Action": "route53:ChangeResourceRecordSets",
+      "Resource": "arn:aws:route53:::hostedzone/*",
+      "Condition": {
+        "ForAllValues:StringLike": {
+          "route53:ChangeResourceRecordSetsNormalizedRecordNames": [
+            "_acme-challenge*.*"
+          ]
+        },
+        "ForAllValues:StringEquals": {
+          "route53:ChangeResourceRecordSetsRecordTypes": [
+            "TXT"
+          ],
+          "route53:ChangeResourceRecordSetsActions": [
+            "CREATE",
+            "UPSERT",
+            "DELETE"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "AllowGetChangeStatus",
+      "Effect": "Allow",
+      "Action": "route53:GetChange",
+      "Resource": "arn:aws:route53:::change/*"
     }
   ]
 }


### PR DESCRIPTION
Hi Christopher, 

I wanted to share the IAM policy I currently use in production. The main change, and you'll see once reading the JSON is that my policy uses new (~2022) fine-grained controls within Route 53 to limit the record type to TXT and only when the domain name contains at least  _acme-challenge.

In theory, this limits the security implications if a bad actor got the access key. 

More technical details can be found in Amazon Documentation: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/specifying-conditions-route53.html 